### PR TITLE
add ipsec module

### DIFF
--- a/dist/modules/ipsec.yml
+++ b/dist/modules/ipsec.yml
@@ -1,0 +1,70 @@
+---
+modules:
+  - name: ipsec
+    namespace: ipsec
+    commands:
+      - command: /ip/ipsec/peer/print
+        prefix: peer
+        labels:
+          - param_name: name
+            param_type: string
+          - param_name: comment
+            param_type: string
+          - param_name: address
+            param_type: string
+            label_name: "remote_address"
+            remap_values_re:
+              - "(.*)/32": "$1"
+          - param_name: "local-address"
+            param_type: string
+            label_name: "local_address"
+        metrics:
+          - param_name: disabled
+            metric_name: enabled
+            param_type: bool
+            metric_type: gauge
+            negate: true
+            default: 1
+      - command: /ip/ipsec/policy/print
+        prefix: policy
+        labels:
+          - param_name: "src-address"
+            param_type: string
+            label_name: "src_address"
+            default: ""
+          - param_name: "dst-address"
+            param_type: string
+            label_name: "dst_address"
+            default: ""
+          - param_name: "sa-src-address"
+            param_type: string
+            label_name: "sa_src_address"
+            default: ""
+            remap_values_re:
+              - "(.*)/32": "$1"
+          - param_name: "sa-dst-address"
+            param_type: string
+            label_name: "sa_dst_address"
+            default: ""
+          - param_name: "peer"
+            param_type: string
+            default: ""
+          - param_name: "comment"
+            param_type: string
+            default: ""
+        metrics:
+          - metric_name: state
+            metric_type: gauge
+            param_type: int
+            value: 1
+            labels:
+              - param_name: "ph2-state"
+                param_type: string
+                label_name: "ph2_state"
+                default: ""
+          - metric_name: "ph2_count"
+            param_name: "ph2-count"
+            param_type: int
+            metric_type: gauge
+            default: 0
+

--- a/dist/modules/ipsec.yml
+++ b/dist/modules/ipsec.yml
@@ -13,8 +13,6 @@ modules:
           - param_name: address
             param_type: string
             label_name: "remote_address"
-            remap_values_re:
-              - "(.*)/32": "$1"
           - param_name: "local-address"
             param_type: string
             label_name: "local_address"
@@ -40,8 +38,6 @@ modules:
             param_type: string
             label_name: "sa_src_address"
             default: ""
-            remap_values_re:
-              - "(.*)/32": "$1"
           - param_name: "sa-dst-address"
             param_type: string
             label_name: "sa_dst_address"
@@ -53,9 +49,10 @@ modules:
             param_type: string
             default: ""
         metrics:
-          - metric_name: state
+          - metric_name: ph2_state
             metric_type: gauge
             param_type: int
+            default: 0
             value: 1
             labels:
               - param_name: "ph2-state"
@@ -67,4 +64,3 @@ modules:
             param_type: int
             metric_type: gauge
             default: 0
-


### PR DESCRIPTION
Hi,

After the BGP monitoring, I've also added a module for IPSec metrics:

- Phase 1 Peers: Is the peer enabled or not? Shows the remote address and the comment
- Phase 2 Policies: show the count of Phase 2 connections, as well as the state of those. The state is not replaced with an integer; instead, each state receives its own label (established, msg1-sent, no-phase2, etc.).

I also wanted to add the "enabled" metric for policies, but that caused a panic in the binary:

~~~yaml
         - param_name: disabled
            param_type: bool
            metric_name: enabled
            metric_type: gauge
            negate: true
            default: 0
~~~
(added to the metrics of `command: /ip/ipsec/policy/print`)

The panic:

~~~
mikrotik-1  | 2025-11-19T10:26:19Z TRC got metric value command_no=1 connection_no=5 metric_name=enabled module=ipsec request_no=2342 sentence_no=0 target=gw01 value=0
mikrotik-1  | 2025/11/19 10:26:19 http: panic serving 172.20.0.1:46604: inconsistent label cardinality: expected 4 label values but got 6 in []string{"0.0.0.0/0", "0.0.0.0/0", "", "", "", ""}
mikrotik-1  | goroutine 728478 [running]:
mikrotik-1  | net/http.(*conn).serve.func1()
mikrotik-1  | 	/opt/hostedtoolcache/go/1.24.5/x64/src/net/http/server.go:1947 +0xbe
mikrotik-1  | panic({0x8aa040?, 0xc000396c60?})
mikrotik-1  | 	/opt/hostedtoolcache/go/1.24.5/x64/src/runtime/panic.go:792 +0x132
mikrotik-1  | github.com/prometheus/client_golang/prometheus.(*GaugeVec).WithLabelValues(0x0?, {0xc0003121e0?, 0xc0002a5800?, 0xd5d020?})
mikrotik-1  | 	/home/runner/go/pkg/mod/github.com/prometheus/client_golang@v1.23.2/prometheus/gauge.go:238 +0x5a
mikrotik-1  | github.com/swoga/mikrotik-exporter/config.(*Metric).createPrometheusGauge.func1({0xc0003121e0?, 0xc00058e378?, 0xc000103250?}, 0x0)
mikrotik-1  | 	/home/runner/work/mikrotik-exporter/mikrotik-exporter/config/metric_logic.go:32 +0x2e
mikrotik-1  | github.com/swoga/mikrotik-exporter/config.(*Metric).AddValue(0xc0001e28a8, {{0x9e9d78, 0xc00058e378}, 0xff, {0x0, 0x0}, {0xc0002a5800, 0x7a, 0x1f4}, {0xc000311de0, ...}, ...}, ...)
mikrotik-1  | 	/home/runner/work/mikrotik-exporter/mikrotik-exporter/config/metric_logic.go:83 +0x283
mikrotik-1  | github.com/swoga/mikrotik-exporter/config.(*Command).addMetrics(0xc0001e2f30, {{0x9e9d78, 0xc00058e378}, 0xff, {0x0, 0x0}, {0xc0002a5800, 0x7a, 0x1f4}, {0xc000311de0, ...}, ...}, ...)
mikrotik-1  | 	/home/runner/work/mikrotik-exporter/mikrotik-exporter/config/command_logic.go:95 +0x346
mikrotik-1  | github.com/swoga/mikrotik-exporter/config.(*Command).processResponse(0xc0001e2f30, {0x9ebdf8, 0xc000294990}, {{0x9e9d78, 0xc00058e378}, 0xff, {0x0, 0x0}, {0xc0002a5800, 0x7a, ...}, ...}, ...)
mikrotik-1  | 	/home/runner/work/mikrotik-exporter/mikrotik-exporter/config/command_logic.go:70 +0x108
mikrotik-1  | github.com/swoga/mikrotik-exporter/config.(*Command).Run(0xc0001e2f30, {0x9ebdf8, 0xc000294990}, {{0x9e9d78, 0xc00058e378}, 0xff, {0x0, 0x0}, {0xc0004d7a00, 0x59, ...}, ...}, ...)
mikrotik-1  | 	/home/runner/work/mikrotik-exporter/mikrotik-exporter/config/command_logic.go:57 +0xac5
mikrotik-1  | github.com/swoga/mikrotik-exporter/config.(*Module).Run(0xc0002b7b40, {0x9ebe30, 0xc000375ef0}, {{0x9e9d78, 0xc00058e378}, 0xff, {0x0, 0x0}, {0xc0004d7a00, 0x59, ...}, ...}, ...)
mikrotik-1  | 	/home/runner/work/mikrotik-exporter/mikrotik-exporter/config/module_logic.go:23 +0x38f
mikrotik-1  | main.runModules({0x9ebe30, 0xc000375ef0}, {{0x9e9d78, 0xc00058e378}, 0xff, {0x0, 0x0}, {0xc0004d7200, 0x48, 0x1f4}, ...}, ...)
mikrotik-1  | 	/home/runner/work/mikrotik-exporter/mikrotik-exporter/cmd/mikrotik-exporter/probe.go:124 +0x3c8
mikrotik-1  | main.probeTarget({0x9ebe30, 0xc000375ef0}, {{0x9e9d78, 0xc00058e378}, 0xff, {0x0, 0x0}, {0xc0004d7200, 0x48, 0x1f4}, ...}, ...)
mikrotik-1  | 	/home/runner/work/mikrotik-exporter/mikrotik-exporter/cmd/mikrotik-exporter/probe.go:100 +0x2fc
mikrotik-1  | main.handleProbeRequest({0x9eb840, 0xc00029e460}, 0xc000214780)
mikrotik-1  | 	/home/runner/work/mikrotik-exporter/mikrotik-exporter/cmd/mikrotik-exporter/probe.go:73 +0x949
mikrotik-1  | net/http.HandlerFunc.ServeHTTP(0xd3bfe0?, {0x9eb840?, 0xc00029e460?}, 0x62ff16?)
mikrotik-1  | 	/opt/hostedtoolcache/go/1.24.5/x64/src/net/http/server.go:2294 +0x29
mikrotik-1  | net/http.(*ServeMux).ServeHTTP(0x46e879?, {0x9eb840, 0xc00029e460}, 0xc000214780)
mikrotik-1  | 	/opt/hostedtoolcache/go/1.24.5/x64/src/net/http/server.go:2822 +0x1c4
mikrotik-1  | net/http.serverHandler.ServeHTTP({0xc00051c4b0?}, {0x9eb840?, 0xc00029e460?}, 0x1?)
mikrotik-1  | 	/opt/hostedtoolcache/go/1.24.5/x64/src/net/http/server.go:3301 +0x8e
mikrotik-1  | net/http.(*conn).serve(0xc0004d4ea0, {0x9ebdf8, 0xc00043c330})
mikrotik-1  | 	/opt/hostedtoolcache/go/1.24.5/x64/src/net/http/server.go:2102 +0x625
mikrotik-1  | created by net/http.(*Server).Serve in goroutine 9
mikrotik-1  | 	/opt/hostedtoolcache/go/1.24.5/x64/src/net/http/server.go:3454 +0x485
~~~
I'm probably just missing a "default" value to add this metric as well.

Thank you for providing the exporter and accepting pull requests!

Best,
Anton